### PR TITLE
Update Docker base image to update cmake

### DIFF
--- a/deployment/docker/client/1604/Dockerfile
+++ b/deployment/docker/client/1604/Dockerfile
@@ -1,4 +1,4 @@
-FROM ceejatec/ubuntu-1604-couchbase-build:20180309
+FROM couchbasebuild/server-ubuntu16-cv:2018112
 
 # We need to export these environment variables
 # as we are using a custom compiled version of GCC

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -49,7 +49,8 @@ also supported, all files are located in ``deployment/docker``.
 
 The following instructions assume that you have a familiarity with Docker, if
 not then please check out the `Docker quickstart guide
-<https://docs.docker.com/engine/getstarted/>`_.
+<https://docs.docker.com/engine/getstarted/>`_. For the Dockerfile to work
+correctly, you will need to run build from the root of your CBNT checkout.
 
 There is a pre-canned version of the server container at
 https://hub.docker.com/r/mattcarabine/cbnt_server and the client container


### PR DESCRIPTION
For progression in kv_engine, we need a newer version of cmake to
run on the Jenkins build. This patch updates the base image used
by the dockerfile, which includes a cmake update.