### PR TITLE
Configure testsuites for master and mad-hatter

### DIFF
--- a/lnt/tests/ep_engine.py
+++ b/lnt/tests/ep_engine.py
@@ -1,8 +1,0 @@
-from couchbase import CouchbaseTest
-
-
-class EpEngineTest(CouchbaseTest):
-    pass
-
-def create_instance():
-    return EpEngineTest()

--- a/lnt/tests/ep_engine_watson.py
+++ b/lnt/tests/ep_engine_watson.py
@@ -1,8 +1,0 @@
-from couchbase import CouchbaseTest
-
-
-class EpEngineWatsonTest(CouchbaseTest):
-    pass
-
-def create_instance():
-    return EpEngineWatsonTest()

--- a/lnt/tests/kv_engine_mad_hatter.py
+++ b/lnt/tests/kv_engine_mad_hatter.py
@@ -1,0 +1,8 @@
+from couchbase import CouchbaseTest
+
+
+class KvEngineMadHatterTest(CouchbaseTest):
+    pass
+
+def create_instance():
+    return KvEngineMadHatterTest()

--- a/lnt/tests/kv_engine_spock.py
+++ b/lnt/tests/kv_engine_spock.py
@@ -1,8 +1,0 @@
-from couchbase import CouchbaseTest
-
-
-class KvEngineSpockTest(CouchbaseTest):
-    pass
-
-def create_instance():
-    return KvEngineSpockTest()

--- a/lnt/tests/kv_engine_testsuites.conf
+++ b/lnt/tests/kv_engine_testsuites.conf
@@ -1,6 +1,6 @@
 [
     {
-        "server-name": "kv-engine",
+        "server-name": "kv_engine",
         "client-name": "kv_engine",
         "server-db-key": "KV"
     }

--- a/lnt/tests/kv_engine_testsuites.conf
+++ b/lnt/tests/kv_engine_testsuites.conf
@@ -1,37 +1,7 @@
 [
-   {
-      "server-name": "memcached", 
-      "client-name": "memcached", 
-      "server-db-key": "Memcached"
-   }, 
-   {
-      "server-name": "ep-engine",
-      "client-name": "ep_engine", 
-      "server-db-key": "EP"
-   }, 
-   {
-      "server-name": "memcached_watson", 
-      "client-name": "memcached_watson", 
-      "server-db-key": "Memcached_watson"
-   }, 
-   {
-      "server-name": "ep-engine_watson", 
-      "client-name": "ep_engine_watson", 
-      "server-db-key": "EP_watson"
-   }, 
-   {
-      "server-name": "kv-engine", 
-      "client-name": "kv_engine", 
-      "server-db-key": "KV"
-   }, 
-   {
-      "server-name": "kv-engine_spock", 
-      "client-name": "kv_engine_spock", 
-      "server-db-key": "KV_spock"
-   }, 
-   {
-      "server-name": "kv-engine_vulcan", 
-      "client-name": "kv_engine_vulcan", 
-      "server-db-key": "KV_vulcan"
-   }
+    {
+        "server-name": "kv-engine",
+        "client-name": "kv_engine",
+        "server-db-key": "KV"
+    }
 ]

--- a/lnt/tests/kv_engine_testsuites.conf
+++ b/lnt/tests/kv_engine_testsuites.conf
@@ -3,5 +3,10 @@
         "server-name": "kv_engine",
         "client-name": "kv_engine",
         "server-db-key": "KV"
+    },
+    {
+        "server-name": "kv_engine_mad_hatter",
+        "client-name": "kv_engine_mad_hatter",
+        "server-db-key": "KV_mad_hatter"
     }
 ]

--- a/lnt/tests/kv_engine_vulcan.py
+++ b/lnt/tests/kv_engine_vulcan.py
@@ -1,7 +1,0 @@
-from couchbase import CouchbaseTest
-
-class KvEngineVulcanTest(CouchbaseTest):
-    pass
-
-def create_instance():
-    return KvEngineVulcanTest()

--- a/lnt/tests/memcached.py
+++ b/lnt/tests/memcached.py
@@ -1,8 +1,0 @@
-from couchbase import CouchbaseTest
-
-
-class MemcachedTest(CouchbaseTest):
-    pass
-
-def create_instance():
-    return MemcachedTest()

--- a/lnt/tests/memcached_watson.py
+++ b/lnt/tests/memcached_watson.py
@@ -1,8 +1,0 @@
-from couchbase import CouchbaseTest
-
-
-class MemcachedWatsonTest(CouchbaseTest):
-    pass
-
-def create_instance():
-    return MemcachedWatsonTest()


### PR DESCRIPTION
The plan is to run cv-perf for master and Mad-Hatter, so we can also remove the pre-MH and the legacy memcached/ep_engine testsuites.