### PR TITLE
Update docker image to use the latest version of server-ubuntu16-cv

### DIFF
--- a/deployment/docker/client/1604/Dockerfile
+++ b/deployment/docker/client/1604/Dockerfile
@@ -1,4 +1,4 @@
-FROM couchbasebuild/server-ubuntu16-cv:20190315
+FROM couchbasebuild/server-ubuntu16-cv:20200211
 
 # We need to export these environment variables
 # as we are using a custom compiled version of GCC


### PR DESCRIPTION
Update cbnt client's docker image to the latest version of
couchbasebuild/server-ubuntu16-cv (20200211) so that we can ensure we
used our forked version of repo what doesn't require us to be using
git version >= 2.10.